### PR TITLE
adding python restrictions for architecturally dependent python package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,15 @@ source:
 
 build:
   number: 1000
-  skip: True  # [not linux]
+  skip: True  # [not linux or py<34]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
 
 requirements:
   host:
     - pip
-    - python >=3.4
+    - python
   run:
-    - python >=3.4
+    - python
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
To allow for a py36 version